### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/in_cloudstack.rb
+++ b/lib/fluent/plugin/in_cloudstack.rb
@@ -10,8 +10,8 @@ module Fluent
     INTERVAL_MIN = 300
 
     config_param :host
-    config_param :apikey
-    config_param :secretkey
+    config_param :apikey, :secret => true
+    config_param :secretkey, :secret => true
 
     config_param :path,        :default => '/client/api'
     config_param :protocol,    :default => 'https'


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature works as below:

``` log
  <source>
    type cloudstack
    host $cloudtack_host
    apikey xxxxxx
    secretkey xxxxxx
    protocol $cloudstack_protocol_scheme
    path $cloudstack_path
    port $cloudstack_port
    interval $get_interval_sec
    ssl $cloudtack_api_ssl
    domain_id $cloudstack_domain_id
    tag $fluentd_tag
    log_dir $fluentd_log_dir
    debug_mode $boolean
  </source>
</ROOT>
```

If one use older fluentd, `:secret => true` will be simply ignored.
