### PR TITLE
Support label feature

### DIFF
--- a/lib/fluent/plugin/in_cloudstack.rb
+++ b/lib/fluent/plugin/in_cloudstack.rb
@@ -98,16 +98,16 @@ module Fluent
       new_events = get_new_events
       new_events.each do |event|
         time = Time.parse(event["created"]).to_i
-        Engine.emit(@event_output_tag, time, event)
+        router.emit(@event_output_tag, time, event)
       end
 
-      Engine.emit("#{@usages_output_tag}", Engine.now, {"events_flow" => new_events.size})
+      router.emit("#{@usages_output_tag}", Engine.now, {"events_flow" => new_events.size})
     end
 
     def emit_usages
       usages = get_usages
 
-      Engine.emit("#{@usages_output_tag}", Engine.now, get_usages)
+      router.emit("#{@usages_output_tag}", Engine.now, get_usages)
     end
 
     def get_new_events

--- a/lib/fluent/plugin/in_cloudstack.rb
+++ b/lib/fluent/plugin/in_cloudstack.rb
@@ -6,6 +6,10 @@ module Fluent
     unless method_defined?(:log)
       define_method("log") { $log }
     end
+    # To support Fluentd v0.10.57 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
 
     INTERVAL_MIN = 300
 


### PR DESCRIPTION
router.emit API causes following effect:
- Fluentd 0.10.57 or earlier -- `.emit`defined in `Fluent::Engine` and Equivalent to Fluent::Engine.emit
- Fluentd 0.10.58 or later --- Nothing to do. Equivarent to Fluent::Engine.emit.
- Fluentd 0.12.0 or later --- Enabled label feature.
